### PR TITLE
fix(libssh): CVE-2026-0966 - heap buffer underflow in ssh_get_hexa()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+libssh (0.11.3-1deepin2) unstable; urgency=medium
+
+  * CVE-2026-0966: Fix heap buffer underflow in ssh_get_hexa()  The
+    ssh_get_hexa() function does not check for NULL pointer input or
+    zero-length input before computing hlen = len * 3, leading to a heap
+    buffer underflow when hlen=0 and hexa[-1] = '\0' is executed.
+    Additionally, no NULL check on the input pointer can lead to a NULL
+    pointer dereference.  This is exploitable remotely during GSSAPI
+    authentication when server logging verbosity is set to
+    SSH_LOG_PACKET (3) or higher.
+
+ -- deepin-ci-robot <packages@deepin.org>  Wed, 03 Jun 2026 09:45:35 +0800
+
 libssh (0.11.3-1deepin1) unstable; urgency=medium
 
   * Fix CVE-2026-3731: out-of-bounds read in sftp_extensions_get_name

--- a/debian/patches/2006-fix-CVE-2026-0966.patch
+++ b/debian/patches/2006-fix-CVE-2026-0966.patch
@@ -1,0 +1,13 @@
+Index: github-libssh-CVE-2026-0966/src/misc.c
+===================================================================
+--- github-libssh-CVE-2026-0966.orig/src/misc.c
++++ github-libssh-CVE-2026-0966/src/misc.c
+@@ -459,7 +459,7 @@ char *ssh_get_hexa(const unsigned char *
+     size_t i;
+     size_t hlen = len * 3;
+ 
+-    if (len > (UINT_MAX - 1) / 3) {
++    if (what == NULL || len < 1 || len > (UINT_MAX - 1) / 3) {
+         return NULL;
+     }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 2003-disable-expand_tilde_unix-test.patch
 2004-install-static-lib.patch
 2005-fix-CVE-2026-3731.patch
+2006-fix-CVE-2026-0966.patch


### PR DESCRIPTION
## CVE 修复

**CVE ID**: CVE-2026-0966

**漏洞描述**: libssh 的 `ssh_get_hexa()` API 函数在处理零长度输入时存在拒绝服务漏洞。当 `len = 0` 时，`hlen = 0`，随后 `hexa[-1] = '\0'` 导致堆缓冲区下溢。攻击者可以在 GSSAPI 认证过程中远程利用此漏洞，前提是服务器日志级别设置为 SSH_LOG_PACKET (3) 或更高。

**修复方案**: 在 `ssh_get_hexa()` 中增加 `what == NULL || len < 1` 检查，当输入为空指针或长度小于 1 时提前返回 NULL。

**受影响版本**: libssh <= 0.11.3

**当前版本**: 0.11.3-1deepin1

**上游修复**: `6ba5ff1b7b1547a59f750fbc06b89737b7456117`

**验证状态**: quilt push 验证通过，补丁正确应用

---

Fix-Approach: patch
Generated by: CVE-Fixer Agent
Co-Authored-By: hudeng <hudeng@deepin.org>